### PR TITLE
新增分頁處理

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ document.addEventListener("DOMContentLoaded", () => {
   const navMenu = document.querySelector("#navbar-menu");
   const search = document.forms[0];
   const table = document.querySelector("#job-pannel");
+  const nextPage = document.querySelector(".pagination-next");
+  let url = "https://still-spire-37210.herokuapp.com/positions.json?";
+  let page = 1;
+
+  getApi(url);
 
   navBurger.addEventListener("click", () => {
     navBurger.classList.toggle("is-active");
@@ -12,7 +17,6 @@ document.addEventListener("DOMContentLoaded", () => {
   search.addEventListener("submit", (e) => {
     e.preventDefault();
 
-    let url = "https://still-spire-37210.herokuapp.com/positions.json?";
     const params = {
       job: search.description.value,
       local: search.location.value,
@@ -28,19 +32,35 @@ document.addEventListener("DOMContentLoaded", () => {
       url += "full_time=true";
     }
 
-    fetch(url)
-      .then(response => {
-        let a = response.json();
-        console.log(a);
-        return a;
-      })
-      .then(promise => {
-        table.innerHTML = "";
-        render(promise);
-      });
+    table.innerHTML = "";
+    getApi(url);    
     
     search.reset();
   });
+
+
+
+  function getApi(url) {
+    fetch(url)
+    .then(response => {
+      let a = response.json();
+      console.log(a);
+      return a;
+    })
+    .then(promise => {
+      render(promise);
+      if (promise.length === 50) {
+        nextPage.removeAttribute("disabled");
+        url += `&page=${++page}`;
+
+        nextPage.addEventListener("click", () => {
+          getApi(url);
+        })
+      } else {
+        nextPage.setAttribute("disabled", true);
+      }
+    });
+  }
   
 
 


### PR DESCRIPTION
Task 4
目標：新增分頁處理

- [x] 當取回來的筆數為 50 筆，可以點選 Next Page 來 load 出更多的結果
- GitHub API 單次最多可取得 50 筆資料
- 取得下一頁資料後，請直接串接在原始資料的下方
- 如果回傳筆數少於 50 筆，代表沒有下一頁可以選，請將 Next Page 按鈕設定為 disable
- [x] 第一次開啟頁面時預設讀取 position.json 的結果，並且一樣可以使用分頁功能